### PR TITLE
Improvements

### DIFF
--- a/dired-filter.el
+++ b/dired-filter.el
@@ -346,7 +346,7 @@ as well."
                           (let* ((predicate (cdr stack))
                                  (predicate-keywords (mapcar (lambda (sym) (intern (concat ":" (symbol-name sym))))
                                                              (-filter 'symbolp (-flatten predicate))))
-                                 (keywords (-intersection dired-utils-attributes-keywords predicate-keywords))
+                                 (keywords (-intersection dired-utils-info-keywords predicate-keywords))
                                  (varlist (mapcar (lambda (keyword)
                                                     `(,(intern (substring (symbol-name keyword) 1))
                                                       (dired-utils-get-info ,keyword))) keywords)))
@@ -667,7 +667,10 @@ separately in turn and ORing the filters together."
 
 QUALIFIER is a lisp sexp that can refer to the following variables:
 
-    `isdir'  [boolean] true if is a directory, string if symlink, or nil
+    `name'   [string]  name of item
+    `isdir'  [boolean] true if is a directory
+    `issym'  [boolean] true if is a symbolic link
+    `target' [string]  the linked-to name for symbolic links
     `nlinks' [integer] number of links to file
     `uid'    [integer] owner
     `gid'    [integer] group
@@ -682,6 +685,7 @@ QUALIFIER is a lisp sexp that can refer to the following variables:
 
 Examples:
   Mark zero-length files: `(equal 0 size)'
+  Find files ending with \"elc\": `(s-ends-with? \"elc\" name)'
   Find files modified before the 01/02/2014: `(time-less-p mtime (date-to-time \"2014-02-01 00:00:00\"))'"
   (:description "predicate"
    :qualifier-description (format "%s" qualifier)


### PR DESCRIPTION
Hello,

Don't merge this yet, there are other commits incoming.

In the meantime, while testing I had some issue trying complicated filters... Basically I was trying the following inside the dired-hacks folder:
- Select files olders than the 22/03/2014 `/ e (> (float-time mtime) (float-time (encode-time 0 0 0 22 3 2014)))` 
- Remove the .git directory `/ h`
- Negate the dotfiles filter `/ !`

So far so good. Now, trying to do the same with `*` instead of `/` and it'll fails, because the doc says:

```
To remove marks that would otherwise be selected by a filter, use
prefix argument (usually bound to C-u). To logically negate the
meaning of the filter, you can call the function with a double
prefix argument (usually C-u C-u)
```
1. How do I negate AND unmark? should we use `C-u C-u C-u`? that looks a bit weird.
2. How do you you negate the results of all filters? `/!` only negates the last filter.
3. `/ TAB` doens't seem to refresh the buffer, but doing `M-x dired-filter-transpose` does. Pressing `g` after doing `/ TAB` shows that it actually worked, no clue why it doesn't refresh.
