### PR TITLE
Allow completion for predicate filters

### DIFF
--- a/dired-filter.el
+++ b/dired-filter.el
@@ -689,7 +689,12 @@ Examples:
   Find files modified before the 01/02/2014: `(time-less-p mtime (date-to-time \"2014-02-01 00:00:00\"))'"
   (:description "predicate"
    :qualifier-description (format "%s" qualifier)
-   :reader (read-minibuffer "Filter by predicate (form): "))
+   :reader (let ((minibuffer-completing-symbol t))
+             (read-from-minibuffer "Filter by predicate (form): "
+                                   nil
+                                   read-expression-map
+                                   t
+                                   'read-expression-history)))
   (eval qualifier))
 
 ;;;###autoload (autoload 'dired-filter-by-directory "dired-filter")


### PR DESCRIPTION
Ripped from `eval-expression`, I'm not sure about the fourth `t` argument for `read-from-minibuffer`, but it seems to work... can you confirm before pulling?

Also, do you have an idea to show the list of available keywords (isdir, name, uid, etc)? In dired+ they make it part of the prompt but imho it'd become a giant prompt. Maybe a custom keymap with `C-h something`?
