### PR TITLE
[filter] Stop putting directory headers in kill-ring

### DIFF
--- a/dired-subtree.el
+++ b/dired-subtree.el
@@ -424,6 +424,7 @@ Return a string suitable for insertion in `dired' buffer."
     (delete-char -1)
     (goto-char (point-min))
     (kill-line 3)
+    (setq kill-ring (cdr kill-ring))
     (insert "  ")
     (while (= (forward-line) 0)
       (insert "  "))


### PR DESCRIPTION
I don't think this negatively impacts the functionality of dired-subtree, based on a few manual tests I just did. But, I don't use any of the other dired utils.

I should probably replace the kill-line all together, but ... I'm lazy and this works. What do you think? :P
