### PR TITLE
[filter] Don't push if the filter is already active

### DIFF
--- a/dired-filter.el
+++ b/dired-filter.el
@@ -361,7 +361,8 @@ operation and the reverting might be costly."
 ;; internals
 (defun dired-filter--push (filter)
   "Push FILTER onto the active filter stack."
-  (push filter dired-filter-stack))
+  (unless (member filter dired-filter-stack)
+    (push filter dired-filter-stack)))
 
 (defun dired-filter--make-filter-1 (stack)
   (cond


### PR DESCRIPTION
Currently the filter is just pushed, so that I have e.g. `[omit] [omit] [omit]` (which is not THAT useful ;) ).

I am not sure if the simple member check suffices however after a quick manual test it works for me currently.

24pullrequests
![24pullrequests](http://24pullrequests.com/assets/logo-625222452ffc0d57272decb6f851a7fe.png)

Best,
Markus
