### PR TITLE
Compile warnings

### DIFF
--- a/dired-subtree.el
+++ b/dired-subtree.el
@@ -83,6 +83,7 @@
 
 (require 'dired-hacks-utils)
 (require 'dash)
+(require 'cl-lib)
 
 (defgroup dired-subtree ()
   "Insert subdirectories in a tree-like fashion."
@@ -589,13 +590,13 @@ the subtree.  The filter action is read from `dired-filter-map'."
             (glob (current-global-map))
             (loc (current-local-map))
             cmd)
-        (flet ((dired-filter--update
-                ()
-                (save-restriction
-                  (overlay-put ov 'dired-subtree-filter dired-filter-stack)
-                  (widen)
-                  (dired-subtree-revert)
-                  (dired-subtree--filter-update-bs ov))))
+        (cl-flet ((dired-filter--update
+                   ()
+                   (save-restriction
+                     (overlay-put ov 'dired-subtree-filter dired-filter-stack)
+                     (widen)
+                     (dired-subtree-revert)
+                     (dired-subtree--filter-update-bs ov))))
           (unwind-protect
               (progn
                 (use-global-map dired-filter-map)


### PR DESCRIPTION
Fixes some compilation warnings when installing in emacs via melpa.

Please have a look at the `arg` to `kill-siblings` change I _guess_ this is what was meant.

24pullrequests
![24pullrequests](http://24pullrequests.com/assets/logo-625222452ffc0d57272decb6f851a7fe.png)

Best,
Markus
