### PR TITLE
Fix issue when trying to expand non-directory lines over tramp

### DIFF
--- a/dired-subtree.el
+++ b/dired-subtree.el
@@ -449,7 +449,8 @@ children."
 Return a string suitable for insertion in `dired' buffer."
   (with-temp-buffer
     (let ((insert-dir-fun  (if (and (featurep 'tramp)
-                                    (tramp-tramp-file-p dir-name))
+                                    (tramp-tramp-file-p dir-name)
+                                    (tramp-sh-handle-file-directory-p dir-name))
                                #'tramp-handle-insert-directory
                              #'insert-directory)))
       (funcall insert-dir-fun dir-name dired-listing-switches nil t))


### PR DESCRIPTION
This prevents trying to use `tramp-handle-insert-directory` to expand a file name over tramp. It doesn't handle file name lines correctly. 