### PR TITLE
dired-insert-set-properties included in let block

### DIFF
--- a/dired-narrow.el
+++ b/dired-narrow.el
@@ -96,9 +96,9 @@
 (defun dired-narrow--restore ()
   "Restore the invisible files of the current buffer."
   (let ((inhibit-read-only t))
-    (remove-text-properties (point-min) (point-max) '(invisible)))
-  (when (fboundp 'dired-insert-set-properties)
-    (dired-insert-set-properties (point-min) (point-max))))
+    (remove-text-properties (point-min) (point-max) '(invisible))
+    (when (fboundp 'dired-insert-set-properties)
+      (dired-insert-set-properties (point-min) (point-max)))))
 
 
 ;; Live filtering


### PR DESCRIPTION
Fix to @Fuco1's narrowing patch. See #42.