### PR TITLE
restrict regex in the example

### DIFF
--- a/README.md
+++ b/README.md
@@ -353,7 +353,7 @@ Here are some example uses:
                            :italic t) ".*\\.log")
 
 ; highlight executable files, but not directories
-(dired-rainbow-define-chmod executable-unix "Green" "-.*x.*")
+(dired-rainbow-define-chmod executable-unix "Green" "-[rw-]+x.*")
 ```
 
 <a name="dired-subtree" />


### PR DESCRIPTION
Otherwise it matches listings if a username contains 'x' letter (my case).
This behaviour puzzled me for a while.