### PR TITLE
[narrow] call an exit action if there is only one file left

### DIFF
--- a/README.md
+++ b/README.md
@@ -489,11 +489,14 @@ You can customize the binding by changing `dired-narrow-map`.
 
 You can customize what happens after exiting the live filtering mode
 by customizing `dired-narrow-exit-action`.
-`dired-narrow-exit-action` may be executed automatically, 
+`dired-narrow-exit-action` may be executed automatically,
 when there is only one file left while narrowing.
 In order to enable this feature, add `(setq dired-narrow-exit-when-1-left t)` to your config.
 It makes sense when you use find-file as your exit action, e.g.
 `(setq dired-narrow-exit-action 'dired-narrow-find-file)`.
+A chosen file will be quickly highlighted before executing `dired-narrow-exit-action`.
+This behavior is controlled by variables `dired-narrow-enable-blinking`,
+`dired-narrow-blink-time` and by a face `dired-narrow-blink`.
 
 
 These narrowing functions are provided:

--- a/README.md
+++ b/README.md
@@ -489,6 +489,12 @@ You can customize the binding by changing `dired-narrow-map`.
 
 You can customize what happens after exiting the live filtering mode
 by customizing `dired-narrow-exit-action`.
+`dired-narrow-exit-action` may be executed automatically, 
+when there is only one file left while narrowing.
+In order to enable this feature, add `(setq dired-narrow-exit-when-1-left t)` to your config.
+It makes sense when you use find-file as your exit action, e.g.
+`(setq dired-narrow-exit-action 'dired-narrow-find-file)`.
+
 
 These narrowing functions are provided:
 

--- a/dired-narrow.el
+++ b/dired-narrow.el
@@ -95,25 +95,29 @@ we should act on."
                  (function :tag "Use custom function."))
   :group 'dired-narrow)
 
-(defcustom dired-narrow-exit-when-1-left nil
+(defcustom dired-narrow-exit-when-one-left nil
   "If there is only one file left while narrowing,
-exit minibuffer and call dired-narrow-exit-action."
+exit minibuffer and call `dired-narrow-exit-action'."
+  :type '(boolean)
   :group 'dired-narrow)
 
 (defcustom dired-narrow-enable-blinking t
   "If set to true highlight the chosen file shortly.
-This feature works only when dired-narrow-exit-when-1-left is true."
+This feature works only when `dired-narrow-exit-when-one-left' is true."
+  :type '(boolean)
   :group 'dired-narrow)
 
 (defcustom dired-narrow-blink-time 0.2
   "How long should be highlighted a chosen file.
 Units are seconds."
+  :type '(float)
   :group 'dired-narrow)
 
 (defface dired-narrow-blink
   '((t :background "#eadc62"
        :foreground "black"))
-  "Level 1."
+  "The face used to highlight a chosen file 
+when `dired-narrow-exit-when-one-left' and `dired-narrow-enable-blinking' are true."
   :group 'dired-narrow)
 
 
@@ -139,7 +143,8 @@ Units are seconds."
   "Value of point just before exiting minibuffer.")
 
 (defun dired-narrow--update (filter)
-  "Make the files not matching the FILTER invisible."
+  "Make the files not matching the FILTER invisible.
+ Return the count of visible files that are left after update."
 
   (let ((inhibit-read-only t)
         (visible-files-cnt 0))
@@ -210,10 +215,10 @@ Units are seconds."
         (setq dired-narrow--current-file (dired-utils-get-filename))
         (set-window-point (get-buffer-window (current-buffer)) (point))
 
-        (when (and dired-narrow-exit-when-1-left
+        (when (and dired-narrow-exit-when-one-left
                    visible-files-cnt
                    (= visible-files-cnt 1))
-          (if dired-narrow-enable-blinking
+          (when dired-narrow-enable-blinking
               (dired-narrow--blink-current-file))
           (exit-minibuffer))))))
 

--- a/dired-narrow.el
+++ b/dired-narrow.el
@@ -97,7 +97,25 @@ we should act on."
 
 (defcustom dired-narrow-exit-when-1-left nil
   "If there is only one file left while narrowing,
-exit minibuffer and call dired-narrow-exit-action")
+exit minibuffer and call dired-narrow-exit-action."
+  :group 'dired-narrow)
+
+(defcustom dired-narrow-enable-blinking t
+  "If set to true highlight the chosen file shortly.
+This feature works only when dired-narrow-exit-when-1-left is true."
+  :group 'dired-narrow)
+
+(defcustom dired-narrow-blink-time 0.2
+  "How long should be highlighted a chosen file.
+Units are seconds."
+  :group 'dired-narrow)
+
+(defface dired-narrow-blink
+  '((t :background "#eadc62"
+       :foreground "black"))
+  "Level 1."
+  :group 'dired-narrow)
+
 
 ;; Utils
 
@@ -151,6 +169,17 @@ exit minibuffer and call dired-narrow-exit-action")
     (when (fboundp 'dired-insert-set-properties)
       (dired-insert-set-properties (point-min) (point-max)))))
 
+
+(defun dired-narrow--blink-current-file ()
+  (let* ((beg (line-beginning-position))
+         (end (line-end-position))
+         (overlay (make-overlay beg end)))
+    (overlay-put overlay 'face 'dired-narrow-blink)
+    (redisplay)
+    (sleep-for dired-narrow-blink-time)
+    (discard-input)
+    (delete-overlay overlay)))
+
 
 ;; Live filtering
 
@@ -184,6 +213,8 @@ exit minibuffer and call dired-narrow-exit-action")
         (when (and dired-narrow-exit-when-1-left
                    visible-files-cnt
                    (= visible-files-cnt 1))
+          (if dired-narrow-enable-blinking
+              (dired-narrow--blink-current-file))
           (exit-minibuffer))))))
 
 (defun dired-narrow--internal (filter-function)

--- a/dired-narrow.el
+++ b/dired-narrow.el
@@ -98,19 +98,19 @@ we should act on."
 (defcustom dired-narrow-exit-when-one-left nil
   "If there is only one file left while narrowing,
 exit minibuffer and call `dired-narrow-exit-action'."
-  :type '(boolean)
+  :type 'boolean
   :group 'dired-narrow)
 
 (defcustom dired-narrow-enable-blinking t
   "If set to true highlight the chosen file shortly.
 This feature works only when `dired-narrow-exit-when-one-left' is true."
-  :type '(boolean)
+  :type 'boolean
   :group 'dired-narrow)
 
 (defcustom dired-narrow-blink-time 0.2
   "How long should be highlighted a chosen file.
 Units are seconds."
-  :type '(float)
+  :type 'float
   :group 'dired-narrow)
 
 (defface dired-narrow-blink


### PR DESCRIPTION
It is disabled by default, one need to add `(setq dired-narrow-exit-when-1-left t)` to a config.
A chosen file will be quickly highlighted. I found it useful, because I often kept typing, when file was already chosen, and these keystrokes made a mess in the next buffer.



