### PR TITLE
Better default for dired-avfs-archives.

### DIFF
--- a/dired-avfs.el
+++ b/dired-avfs.el
@@ -53,7 +53,8 @@
   :type 'directory
   :group 'dired-avfs)
 
-(defcustom dired-avfs-archives '("zip" "rar" "tar" "bz2")
+(defcustom dired-avfs-archives
+  '("zip" "rar" "tar" "tar.gz" "tgz" "tar.bz2" "tb2" "tbz2" "tar.xz" "txz")
   "Archives that are automagically opened via avfs."
   :type '(repeat string)
   :group 'dired-avfs)


### PR DESCRIPTION
The current default has a few issues:

- xz and gz are supported but not listed.
- bz2 should be supported when used with tar, since Emacs can handle
  single non-tar files compressed in bz2 better.