### PR TITLE
[collapse] Fix with for additional figures

### DIFF
--- a/dired-collapse.el
+++ b/dired-collapse.el
@@ -127,7 +127,7 @@ COLUMN-INFO is a data structure returned by
         (save-excursion
           (skip-syntax-forward " ")
           (search-forward " ")
-          (- date-column (current-column))))
+          (max 0 (- date-column (current-column)))))
       32))))
 
 (defun dired-collapse ()


### PR DESCRIPTION
(dired-collapse--replace-file) fails when a collapsed file size has more figures than the maximum of already displayed because of a negative value.  The max function guarantees a non negative value.