### PR TITLE
Make dired-collapse-mode work with dired-subtree

### DIFF
--- a/dired-collapse.el
+++ b/dired-collapse.el
@@ -86,6 +86,7 @@
         (unless (= (buffer-size) 0)
           (revert-buffer)))
     (remove-hook 'dired-after-readin-hook 'dired-collapse 'local)
+    (remove-hook 'dired-subtree-after-insert-hook 'dired-collapse 'local)
     (revert-buffer)))
 
 (defun dired-collapse--get-column-info ()

--- a/dired-collapse.el
+++ b/dired-collapse.el
@@ -80,6 +80,7 @@
   (if dired-collapse-mode
       (progn
         (add-hook 'dired-after-readin-hook 'dired-collapse 'append 'local)
+        (add-hook 'dired-subtree-after-insert-hook 'dired-collapse 'append 'local)
         ;; revert the buffer only if it is not empty (= we haven't yet
         ;; read in the current directory)
         (unless (= (buffer-size) 0)


### PR DESCRIPTION
This adds the `dired-subtree-after-insert-hook` so that collapsed
directories will also show up when using dired-subtree.

This addresses #103 