### PR TITLE
Check if file is readable before collapsing.

### DIFF
--- a/dired-collapse.el
+++ b/dired-collapse.el
@@ -109,6 +109,7 @@
       (while (not (eobp))
         (when (and (looking-at-p dired-re-dir)
                    (not (member (dired-get-filename 'no-dir t) (list "." "..")))
+                   (file-readable-p (dired-get-filename nil t))
                    (not (eolp)))
           (let ((path (dired-get-filename nil t))
                 files)


### PR DESCRIPTION
I was getting an issue where I had to go up to `/` from `/home/` but could not and got an error when not accessing as root. This was because dired-collapse was trying to read files (`f-entries`?) from a dir my user has no read access to (specifically, `/lost+found`).  