### PR TITLE
[filter] Update after transpose

### DIFF
--- a/dired-filter.el
+++ b/dired-filter.el
@@ -1164,7 +1164,8 @@ of `auto-mode-alist'."
     (pop dired-filter-stack)
     (pop dired-filter-stack)
     (dired-filter--push top)
-    (dired-filter--push top2)))
+    (dired-filter--push top2)
+    (force-mode-line-update)))
 
 ;;;###autoload
 (defun dired-filter-or ()


### PR DESCRIPTION
Fixes minor bug whereby, after invoking `dired-filter-transpose`, the display shows the old order of filters (in the `Active filters:` header) until next keypress.

It's not necessary to re-run the filters, as `dired-filter--update` does, but it seems cheap enough.  Maybe there's a better way?