### PR TITLE
[narrow] Better regexp searching

### DIFF
--- a/dired-narrow.el
+++ b/dired-narrow.el
@@ -263,7 +263,11 @@ read from minibuffer."
 ;; Interactive
 
 (defun dired-narrow--regexp-filter (filter)
-  (re-search-forward filter (line-end-position) t))
+  (condition-case nil
+      (re-search-forward filter (line-end-position) t)
+    ;; Return t if your regexp is incomplete/has errors, thus
+    ;; filtering nothing until you fix the regexp.
+    (invalid-regexp t)))
 
 ;;;###autoload
 (defun dired-narrow-regexp ()

--- a/dired-narrow.el
+++ b/dired-narrow.el
@@ -264,7 +264,7 @@ read from minibuffer."
 
 (defun dired-narrow--regexp-filter (filter)
   (condition-case nil
-      (re-search-forward filter (line-end-position) t)
+      (string-match-p filter (dired-utils-get-filename 'no-dir))
     ;; Return t if your regexp is incomplete/has errors, thus
     ;; filtering nothing until you fix the regexp.
     (invalid-regexp t)))

--- a/dired-narrow.el
+++ b/dired-narrow.el
@@ -174,7 +174,8 @@ when `dired-narrow-exit-when-one-left' and `dired-narrow-enable-blinking' are tr
 (defun dired-narrow--restore ()
   "Restore the invisible files of the current buffer."
   (let ((inhibit-read-only t))
-    (remove-text-properties (point-min) (point-max) '(invisible))
+    (remove-list-of-text-properties (point-min) (point-max)
+                                    '(invisible :dired-narrow))
     (when (fboundp 'dired-insert-set-properties)
       (dired-insert-set-properties (point-min) (point-max)))))
 


### PR DESCRIPTION
Three potential improvements here.  Here's how you can test each:

399af4e: Run `dired-narrow-regexp`, type any invalid regexp such as just a backslash (`\`).  Before this commit, you'll immediately get an error and any further input to `dired-narrow-regexp` will have no effect (though it lets you keep typing).  After this commit you can finish your regexp, such as `\(x\)`.

0dce1f7: Before this change, run `dired-narrow-regexp` and try to find a file name using the `^` to anchor the match at the beginning of the file.  For example, `^dired-narrow` will not match anything.  After this change, `^` matches beginning of file names, which I think is probably useful.

368277b04ad0a224f377f83b1fc28d98076e474b: I think this probably affects any dired-narrow command, but I was testing with `dired-narrow-regexp`, so run that, type any character that doesn't appear in any file name (ex. `{` is uncommon), then backspace it, enter any pattern that will match a file, and accept it.  Before this commit, when you exit `dired-narrow-regexp` no files will be shown because that's what was matched with the `{` pattern and the `:dired-narrow` text properties were never removed when you backspaced.  After this commit, backspacing and entering a new pattern will correctly narrow to your new pattern.

I hope it's not too ugly that I submitted these all in one PR, let me know if you want me to split them up, or if you'd like any further explanation or find problems.  Thanks for writing and publishing these "hacks"!