### PR TITLE
dired-rainbow-file-regexp-group

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,9 @@ This package also provides these interactive functions:
 * `dired-hacks-next-file` - go to next file, skipping empty and non-file lines
 * `dired-hacks-previous-file` - go to previous file, skipping empty
   and non-file lines
+* `dired-utils-format-information-line-mode` - Format the information
+  (summary) line file sizes to be human readable (e.g. 1GB instead of
+  1048576).
 
 ## dired-filter
 

--- a/dired-rainbow.el
+++ b/dired-rainbow.el
@@ -68,19 +68,6 @@
   :group 'dired-hacks
   :prefix "dired-rainbow-")
 
-(defcustom dired-rainbow-date-regexp "\\sw\\sw\\sw....\\(?:[0-9][0-9]:[0-9][0-9]\\|.[0-9]\\{4\\}\\)"
-  "A regexp matching the date/time in the dired listing.
-
-It is used to determine where the filename starts.  It should
-*not* match any characters after the last character of the
-timestamp.  It is assumed that the timestamp is preceded and
-followed by at least one space character.  You should only use
-shy groups (prefixed with ?:) because the first group is used by
-the font-lock to determine what portion of the name should be
-colored."
-  :type 'string
-  :group 'dired-rainbow)
-
 (defvar dired-rainbow-ext-to-face nil
   "An alist mapping extension groups to face and compiled regexp.
 
@@ -130,7 +117,7 @@ to control the order."
                     (symbol-value extensions)))
          (regexp (concat
                   "^[^!].[^d].*[ ]"
-                  dired-rainbow-date-regexp
+                  dired-hacks-datetime-regexp
                   "[ ]\\("
                   (if (listp matcher)
                       (concat ".*\\." (regexp-opt matcher))
@@ -176,7 +163,7 @@ to control the order."
                   "^[^!]."
                   chmod
                   ".*[ ]"
-                  dired-rainbow-date-regexp
+                  dired-hacks-datetime-regexp
                   "[ ]\\(.*?\\)$"))
          (face-name (intern (concat "dired-rainbow-" (symbol-name symbol) "-face"))))
     `(progn

--- a/dired-rainbow.el
+++ b/dired-rainbow.el
@@ -68,6 +68,18 @@
   :group 'dired-hacks
   :prefix "dired-rainbow-")
 
+(defcustom dired-rainbow-file-regexp-group 0
+  "The group number to use for font locking the file name.
+
+It is used to determine which parts of the file name to font
+lock. The number is the regexp group.
+
+0: The entire file name.
+1: The file name sans extension.
+2: Only the file extension."
+  :type 'number
+  :group 'dired-rainbow)
+
 (defvar dired-rainbow-ext-to-face nil
   "An alist mapping extension groups to face and compiled regexp.
 
@@ -120,7 +132,7 @@ to control the order."
                   dired-hacks-datetime-regexp
                   "[ ]\\("
                   (if (listp matcher)
-                      (concat ".*\\." (regexp-opt matcher))
+                      (concat ".*\\)\\(\\." (regexp-opt matcher))
                     matcher)
                   "\\)$"))
          (face-name (intern (concat "dired-rainbow-" (symbol-name symbol) "-face"))))
@@ -129,8 +141,12 @@ to control the order."
          '((t ,(dired-rainbow--get-face face-props)))
          ,(concat "dired-rainbow face matching " (symbol-name symbol) " files.")
          :group 'dired-rainbow)
-       (font-lock-add-keywords 'dired-mode '((,regexp 1 ',face-name)) ,how)
-       (font-lock-add-keywords 'wdired-mode '((,regexp 1 ',face-name)) ,how)
+       (font-lock-add-keywords 'dired-mode
+                               '((,regexp ,dired-rainbow-file-regexp-group
+                                          ',face-name nil prepend)) ,how)
+       (font-lock-add-keywords 'wdired-mode
+                               '((,regexp ,dired-rainbow-file-regexp-group
+                                          ',face-name nil prepend)) ,how)
        ,(if (listp matcher) `(push
                               '(,matcher ,face-name ,(concat "\\." (regexp-opt matcher)))
                               dired-rainbow-ext-to-face)))))


### PR DESCRIPTION
Adds configurability of the file name font locking region. Partially (and probably satisfactorily) addresses #151.