### PR TITLE
Merge dired-rainbow faces with existing

### DIFF
--- a/dired-rainbow.el
+++ b/dired-rainbow.el
@@ -129,8 +129,8 @@ to control the order."
          '((t ,(dired-rainbow--get-face face-props)))
          ,(concat "dired-rainbow face matching " (symbol-name symbol) " files.")
          :group 'dired-rainbow)
-       (font-lock-add-keywords 'dired-mode '((,regexp 1 ',face-name)) ,how)
-       (font-lock-add-keywords 'wdired-mode '((,regexp 1 ',face-name)) ,how)
+       (font-lock-add-keywords 'dired-mode '((,regexp 1 ',face-name prepend)) ,how)
+       (font-lock-add-keywords 'wdired-mode '((,regexp 1 ',face-name prepend)) ,how)
        ,(if (listp matcher) `(push
                               '(,matcher ,face-name ,(concat "\\." (regexp-opt matcher)))
                               dired-rainbow-ext-to-face)))))
@@ -171,8 +171,8 @@ to control the order."
          '((t ,(dired-rainbow--get-face face-props)))
          ,(concat "dired-rainbow face matching " (symbol-name symbol) " files.")
          :group 'dired-rainbow)
-       (font-lock-add-keywords 'dired-mode '((,regexp 1 ',face-name)) ,how)
-       (font-lock-add-keywords 'wdired-mode '((,regexp 1 ',face-name)) ,how))))
+       (font-lock-add-keywords 'dired-mode '((,regexp 1 ',face-name prepend)) ,how)
+       (font-lock-add-keywords 'wdired-mode '((,regexp 1 ',face-name prepend)) ,how))))
 
 (provide 'dired-rainbow)
 


### PR DESCRIPTION
Allows [diredfl](https://github.com/purcell/diredfl) and dired-rainbow to work together. Now if rainbow rules come after diredfl, the rainbow face will be merged on top of diredfl's:
![Screenshot](https://i.imgur.com/adr2bGv.png)

The small bold extensions are powered by `diredfl-file-suffix` and the green color for ".dir-locals.el" is from dired-rainbow.

For the merging behavior, set `HOW` to non-nil so rainbow runs after diredfl. If you prefer the old behavior of replacing diredfl, leave `HOW` nil. diredfl will not touch already-fontified text.