### PR TITLE
Improve directories filtering

### DIFF
--- a/dired-filter.el
+++ b/dired-filter.el
@@ -1131,7 +1131,8 @@ Examples:
 (dired-filter-define directory
     "Toggle current view to show only directories."
   (:description "directory")
-  (or (looking-at dired-re-dir)
+  (or (and (looking-at-p dired-re-dir)
+           (not (looking-at-p dired-re-dot)))
       (and (looking-at dired-re-sym)
            (file-directory-p (dired-utils-get-filename)))))
 


### PR DESCRIPTION
Hello,

I'm revisiting dired-filter these days and I wonder if there's something to do about `dired-filter-mark-by-directory` vs `dired-mark-directories`.

They both behave in a similar fashion, except `dired-mark-directories` does not mark `. ` and `..`

I wonder which one makes more sense, e.g if you want to delete all directories `dired-filter-mark-directories` followed by `D` would attempt to delete `.` and `..`, which is likely not what you want. But at the same time it is more "correct" in the sense it really marks directories. I think overall it's a bit unexpected that `.` and `..` are considered when filtering/marking.

I also noticed dired treats `.` and `..` in a special way because they are never toggled for example. And I found #6 which is somewhat related.

Anway, I'm not sure what I want here but maybe simply your thoughts about it :-)