### PR TITLE
fix package-lint/check-doc/byte-compiler warnings

### DIFF
--- a/dired-avfs.el
+++ b/dired-avfs.el
@@ -4,10 +4,11 @@
 
 ;; Author: Matus Goljer <matus.goljer@gmail.com>
 ;; Maintainer: Matus Goljer <matus.goljer@gmail.com>
-;; Keywords: files
 ;; Version: 0.0.1
 ;; Created: 14th February 2014
-;; Package-requires: ((dash "2.5.0") (dired-hacks-utils "0.0.1"))
+;; Keywords: files
+;; Package-requires: ((emacs "24") (dash "2.5.0") (dired-hacks-utils "0.0.1"))
+;; URL: https://github.com/Fuco1/dired-hacks
 
 ;; This program is free software; you can redistribute it and/or modify
 ;; it under the terms of the GNU General Public License as published by
@@ -119,7 +120,7 @@ directory representing this archive."
                  (not (tramp-tramp-file-p (ad-get-arg 0))))
              (dired-avfs--archive-p (ad-get-arg 0))
              (if (> (nth 7 (file-attributes (ad-get-arg 0))) (* dired-avfs-file-size-threshold 1048576))
-                 (y-or-n-p (format "Size of this file exceeds `dired-avfs-file-size-threshold' (%d MB), extracting the information might take very long time.  Do you want to continue?"
+                 (y-or-n-p (format "Size of this file exceeds `dired-avfs-file-size-threshold' (%d MB), extracting the information might take very long time.  Do you want to continue? "
                                    dired-avfs-file-size-threshold))
                t))
     (ad-set-arg 0 (dired-avfs--archive-filename (ad-get-arg 0)))))

--- a/dired-collapse.el
+++ b/dired-collapse.el
@@ -6,8 +6,9 @@
 ;; Maintainer: Matúš Goljer <matus.goljer@gmail.com>
 ;; Version: 1.1.0
 ;; Created: 15th July 2017
-;; Package-requires: ((dash "2.10.0") (f "0.19.0") (dired-hacks-utils "0.0.1"))
 ;; Keywords: files
+;; Package-requires: ((emacs "24") (dash "2.10.0") (f "0.19.0") (dired-hacks-utils "0.0.1"))
+;; URL: https://github.com/Fuco1/dired-hacks
 
 ;; This program is free software; you can redistribute it and/or
 ;; modify it under the terms of the GNU General Public License

--- a/dired-filter.el
+++ b/dired-filter.el
@@ -4,10 +4,11 @@
 
 ;; Author: Matúš Goljer <matus.goljer@gmail.com>
 ;; Maintainer: Matúš Goljer <matus.goljer@gmail.com>
-;; Keywords: files
 ;; Version: 0.0.2
 ;; Created: 14th February 2014
-;; Package-requires: ((dash "2.10.0") (dired-hacks-utils "0.0.1") (f "0.17.0") (cl-lib "0.3"))
+;; Keywords: files
+;; Package-requires: ((emacs "24") (dash "2.10.0") (dired-hacks-utils "0.0.1") (f "0.17.0") (cl-lib "0.3"))
+;; URL: https://github.com/Fuco1/dired-hacks
 
 ;; This program is free software; you can redistribute it and/or modify
 ;; it under the terms of the GNU General Public License as published by
@@ -394,7 +395,7 @@ See `dired-filter-stack' for the format of FILTER-STACK."
   :group 'dired-filter-group)
 
 (defconst dired-filter-group-imenu-generic-expression '("Group" "^ *\\[ \\(.*\\) \\]" 1)
-  "An alist of menus for accessing locations in documents with imenu
+  "An alist of menus for accessing locations in documents with imenu.
 
 It is a list of lists of the form
 \(MENU-TITLE REGEXP INDEX [FUNCTION] [ARGUMENTS...])
@@ -510,7 +511,7 @@ Setter for `dired-filter-mark-prefix' user variable."
    ((stringp stack)
     `(and ,@(mapcar 'dired-filter--make-filter-1
                     (or (cdr (assoc stack dired-filter-saved-filters))
-                        (error "saved filter %s does not exist" stack)))))
+                        (error "A saved filter %s does not exist" stack)))))
    ((stringp (car stack))
     `(and ,@(mapcar 'dired-filter--make-filter-1 (cdr stack))))
    ((eq (car stack) 'or)
@@ -605,7 +606,7 @@ STACK is a filter stack with the format of `dired-filter-stack'."
            ((eq dired-filter-revert 'always) t)
            ((eq dired-filter-revert 'ask)
             (not (y-or-n-p "It appears the revert function for this dired buffer is non-standard.  Reverting might take a long time.
-Do you want to apply the filters without reverting (this might provide incorrect results in some situations)?"))))
+Do you want to apply the filters without reverting (this might provide incorrect results in some situations)? "))))
           (revert-buffer)
         (dired-filter--apply)))
     (if (and dired-filter-mode
@@ -855,14 +856,13 @@ filter"
 (defun dired-filter--mark (filter)
   "Helper used by `dired-filter-mark-by-' family.
 
-This ORs the current selection with the one specified by selected filter.
+This ORs the current selection with the one specified by selected FILTER.
 
 If prefix argument \\[universal-argument] is used, unmark the matched files instead
 \(including any previously marked files).
 
 If prefix argument \\[universal-argument] \\[universal-argument] is used, mark the files that would normally
-not be marked, that is, reverse the logical meaning of the
-filter."
+not be marked, that is, reverse the logical meaning of the filter."
   (let* ((remove (cl-cadddr (assoc (car filter) dired-filter-alist)))
          (filter (if (equal current-prefix-arg '(16))
                      `(not ,(dired-filter--make-filter (list filter)))
@@ -1237,7 +1237,7 @@ push all its constituents back on the stack."
   (let ((top (car dired-filter-stack)))
     (if (not (or (eq (car top) 'or)
                  (eq (car top) 'not)))
-        (error "You can only decompose `or' or `not' filters.")
+        (error "You can only decompose `or' or `not' filters")
       (pop dired-filter-stack)
       (--each (nreverse (cdr top))
         (dired-filter--push it))

--- a/dired-hacks-utils.el
+++ b/dired-hacks-utils.el
@@ -4,10 +4,11 @@
 
 ;; Author: Matúš Goljer <matus.goljer@gmail.com>
 ;; Maintainer: Matúš Goljer <matus.goljer@gmail.com>
-;; Keywords: files
 ;; Version: 0.0.1
 ;; Created: 14th February 2014
-;; Package-requires: ((dash "2.5.0"))
+;; Keywords: files
+;; Package-requires: ((emacs "24.3") (dash "2.5.0"))
+;; URL: https://github.com/Fuco1/dired-hacks
 
 ;; This program is free software; you can redistribute it and/or modify
 ;; it under the terms of the GNU General Public License as published by

--- a/dired-list.el
+++ b/dired-list.el
@@ -6,8 +6,9 @@
 ;; Maintainer: Matúš Goljer <matus.goljer@gmail.com>
 ;; Version: 0.0.1
 ;; Created: 14th February 2014
-;; Package-requires: ((dash "2.10.0"))
 ;; Keywords: files
+;; Package-requires: ((emacs "24.3") (dash "2.10.0"))
+;; URL: https://github.com/Fuco1/dired-hacks
 
 ;; This program is free software; you can redistribute it and/or
 ;; modify it under the terms of the GNU General Public License
@@ -45,7 +46,7 @@
 
 ;;   C-h f dired-list RET
 
-;; in emacs.
+;; in Emacs.
 
 ;; In addition to the generic interface this package implements common
 ;; listings (patches and extensions welcome!), these are:

--- a/dired-narrow.el
+++ b/dired-narrow.el
@@ -6,8 +6,9 @@
 ;; Maintainer: Matúš Goljer <matus.goljer@gmail.com>
 ;; Version: 0.0.1
 ;; Created: 14th February 2014
-;; Package-requires: ((dash "2.7.0") (dired-hacks-utils "0.0.1"))
 ;; Keywords: files
+;; Package-requires: ((emacs "24") (dash "2.7.0") (dired-hacks-utils "0.0.1"))
+;; URL: https://github.com/Fuco1/dired-hacks
 
 ;; This program is free software; you can redistribute it and/or
 ;; modify it under the terms of the GNU General Public License
@@ -148,7 +149,7 @@ when `dired-narrow-exit-when-one-left' and `dired-narrow-enable-blinking' are tr
 
 (defun dired-narrow--update (filter)
   "Make the files not matching the FILTER invisible.
- Return the count of visible files that are left after update."
+Return the count of visible files that are left after update."
 
   (let ((inhibit-read-only t)
         (visible-files-cnt 0))

--- a/dired-open.el
+++ b/dired-open.el
@@ -4,10 +4,11 @@
 
 ;; Author: Matúš Goljer <matus.goljer@gmail.com>
 ;; Maintainer: Matúš Goljer <matus.goljer@gmail.com>
-;; Keywords: files
 ;; Version: 0.0.1
 ;; Created: 14th February 2014
-;; Package-requires: ((dash "2.5.0") (dired-hacks-utils "0.0.1"))
+;; Keywords: files
+;; Package-requires: ((emacs "24") (dash "2.5.0") (dired-hacks-utils "0.0.1"))
+;; URL: https://github.com/Fuco1/dired-hacks
 
 ;; This program is free software; you can redistribute it and/or modify
 ;; it under the terms of the GNU General Public License as published by
@@ -24,14 +25,14 @@
 
 ;;; Commentary:
 
-;; While emacs already has the `auto-mode-alist', this is often
+;; While Emacs already has the `auto-mode-alist', this is often
 ;; insufficient.  Many times, you want to open media files, pdfs or
 ;; other documents with an external application.  There's remedy for
 ;; that too, namely `dired-guess-shell-alist-user', but that is still
 ;; not as convenient as just hitting enter.
 
 ;; This package adds a mechanism to add "hooks" to `dired-find-file'
-;; that will run before emacs tries its own mechanisms to open the
+;; that will run before Emacs tries its own mechanisms to open the
 ;; file, thus enabling you to launch other application or code and
 ;; suspend the default behaviour.
 
@@ -112,7 +113,7 @@ The filename is passed as the only argument to the function."
 
 (defcustom dired-open-use-nohup t
   "If non-nil, use nohup(1) to keep external processes opened
-even if emacs process is terminated.
+even if Emacs process is terminated.
 
 This only affects the built-in handlers."
   :type 'boolean
@@ -120,7 +121,7 @@ This only affects the built-in handlers."
 
 (defcustom dired-open-query-before-exit t
   "If non-nil, ask the user if they want to kill any external
-processes started by `dired-open-file' when they exit emacs.
+processes started by `dired-open-file' when they exit Emacs.
 
 This only affects the built-in handlers."
   :type 'boolean

--- a/dired-rainbow.el
+++ b/dired-rainbow.el
@@ -4,11 +4,11 @@
 
 ;; Author: Matus Goljer <matus.goljer@gmail.com>
 ;; Maintainer: Matus Goljer <matus.goljer@gmail.com>
-;; Keywords: files
-;; Package-Version: 20170922.817
 ;; Version: 0.0.3
 ;; Created: 16th February 2014
-;; Package-requires: ((dash "2.5.0") (dired-hacks-utils "0.0.1"))
+;; Keywords: files
+;; Package-requires: ((emacs "24") (dash "2.5.0") (dired-hacks-utils "0.0.1"))
+;; URL: https://github.com/Fuco1/dired-hacks
 
 ;; This program is free software; you can redistribute it and/or modify
 ;; it under the terms of the GNU General Public License as published by

--- a/dired-ranger.el
+++ b/dired-ranger.el
@@ -6,8 +6,9 @@
 ;; Maintainer: Matúš Goljer <matus.goljer@gmail.com>
 ;; Version: 0.0.1
 ;; Created: 17th June 2014
-;; Package-requires: ((dash "2.7.0") (dired-hacks-utils "0.0.1"))
 ;; Keywords: files
+;; Package-requires: ((emacs "24.3") (dash "2.7.0") (dired-hacks-utils "0.0.1"))
+;; URL: https://github.com/Fuco1/dired-hacks
 
 ;; This program is free software; you can redistribute it and/or
 ;; modify it under the terms of the GNU General Public License
@@ -78,7 +79,7 @@
 ;; very fast way.
 
 ;; These bookmarks are not persistent.  If you want persistent
-;; bookmarks use the bookmarks provided by emacs, see (info "(emacs)
+;; bookmarks use the bookmarks provided by Emacs, see (info "(emacs)
 ;; Bookmarks").
 
 ;;; Code:
@@ -288,7 +289,7 @@ See also `dired-ranger-bookmark'."
                ((eq dired-ranger-bookmark-reopen 'never) nil)
                ((eq dired-ranger-bookmark-reopen 'always) t)
                ((eq dired-ranger-bookmark-reopen 'ask)
-                (y-or-n-p (format "The dired buffer referenced by this bookmark does not exist.  Should we try to reopen `%s'?" dir))))
+                (y-or-n-p (format "The dired buffer referenced by this bookmark does not exist.  Should we try to reopen `%s'? " dir))))
             (find-file dir)
             (setf (cdr (assoc char dired-ranger-bookmarks)) (cons dir (current-buffer)))))
       (message "Bookmark `%c' does not exist." char))))

--- a/dired-subtree.el
+++ b/dired-subtree.el
@@ -4,10 +4,11 @@
 
 ;; Author: Matúš Goljer <matus.goljer@gmail.com>
 ;; Maintainer: Matúš Goljer <matus.goljer@gmail.com>
-;; Keywords: files
 ;; Version: 0.0.1
 ;; Created: 25th February 2014
-;; Package-requires: ((dash "2.5.0") (dired-hacks-utils "0.0.1"))
+;; Keywords: files
+;; Package-requires: ((emacs "24.3") (dash "2.5.0") (dired-hacks-utils "0.0.1"))
+;; URL: https://github.com/Fuco1/dired-hacks
 
 ;; This program is free software; you can redistribute it and/or modify
 ;; it under the terms of the GNU General Public License as published by
@@ -56,7 +57,7 @@
 
 ;; Here's a list of available interactive functions.  You can read
 ;; more about each one by using the built-in documentation facilities
-;; of emacs.  It is adviced to place bindings for these into a
+;; of Emacs.  It is adviced to place bindings for these into a
 ;; convenient prefix key map, for example C-,
 
 ;; * `dired-subtree-insert'
@@ -190,7 +191,7 @@ depth---that creates the prefix."
   (mapc 'dired-subtree--remove-overlay ovs))
 
 (defun dired-subtree--cleanup-overlays ()
-  "Remove the `nil' values from `dired-subtree-overlays'."
+  "Remove the nil values from `dired-subtree-overlays'."
   (setq dired-subtree-overlays
         (--remove (not (overlay-buffer it)) dired-subtree-overlays)))
 
@@ -277,7 +278,7 @@ If no SUBTREES are specified, use `dired-subtree-overlays'."
   (save-excursion (dired-unmark 1)))
 
 (defun dired-subtree--dired-line-is-directory-or-link-p ()
-  "Return non-nil if line under point is a directory or symlink"
+  "Return non-nil if line under point is a directory or symlink."
   ;; We've replaced `file-directory-p' with the regexp test to
   ;; speed up filters over TRAMP.  So long as dired/ls format
   ;; doesn't change, we're good.
@@ -760,7 +761,7 @@ Optional argument means return a file name relative to `default-directory'."
 ;; Since the tree-inserted directory is not in the dired-subdir-alist,
 ;; we need to guard against nil.
 (defun dired-get-subdir ()
-  ;;"Return the subdir name on this line, or nil if not on a headerline."
+  "Return the subdir name on this line, or nil if not on a headerline."
   ;; Look up in the alist whether this is a headerline.
   (save-excursion
     (let ((cur-dir (dired-current-directory)))

--- a/dired-tagsistant.el
+++ b/dired-tagsistant.el
@@ -6,8 +6,9 @@
 ;; Maintainer: Matúš Goljer <matus.goljer@gmail.com>
 ;; Version: 0.0.1
 ;; Created: 14th February 2014
-;; Package-requires: ((dash "2.8.0") (dired-hacks-utils "0.0.1") (f "0.16") (s "1.7.0"))
 ;; Keywords: files
+;; Package-requires: ((emacs "24.3") (dash "2.8.0") (dired-hacks-utils "0.0.1") (f "0.16") (s "1.7.0"))
+;; URL: https://github.com/Fuco1/dired-hacks
 
 ;; This program is free software; you can redistribute it and/or
 ;; modify it under the terms of the GNU General Public License


### PR DESCRIPTION
Hi!
I found those packages and fix some package-lint/check-doc/byte-compiler warnings for my first contribution step!
## dired-avfs
### before
```
 dired-av…     1   1 error           Package should have a Homepage or URL header. (emacs-lisp-package)
 dired-a…   122     warning         `y-or-n-p' argument should end with "? " (emacs-lisp-checkdoc)
```

### after
No issues!

## dired-collapse
### before
```
 dired-col…     1   1 error           Package should have a Homepage or URL header. (emacs-lisp-package)
 dired-co…     1  77 warning         You should depend on (emacs "24") if you need lexical-binding. (emacs-lisp-package)
 dired-c…   110     warning         Probably "marks" should be imperative "mark" (emacs-lisp-checkdoc)
```

### after
```
 dired-c…   111     warning         Probably "marks" should be imperative "mark" (emacs-lisp-checkdoc)
```

## dired-filter
### before
```
 dired-fil…     1   1 error           Package should have a Homepage or URL header. (emacs-lisp-package)
 dired-f…     1  62 warning         You should depend on (emacs "24") if you need lexical-binding. (emacs-lisp-package)
 dired-f…   397     warning         First line is not a complete sentence (emacs-lisp-checkdoc)
 dired-f…   404     warning         All variables and subroutines might as well have a documentation string (emacs-lisp-checkdoc)
 dired-f…   407     warning         All variables and subroutines might as well have a documentation string (emacs-lisp-checkdoc)
 dired-f…   513     warning         Messages should start with a capital letter (emacs-lisp-checkdoc)
 dired-f…   608     warning         `y-or-n-p' argument should end with "? " (emacs-lisp-checkdoc)
 dired-…   856     warning         Argument ‘filter’ should appear (as FILTER) in the doc string (emacs-lisp-checkdoc)
 dired-…  1240     warning         Error messages should *not* end with a period (emacs-lisp-checkdoc)
 dired-…  1248     warning         Argument ‘arg’ should appear (as ARG) in the doc string (emacs-lisp-checkdoc)
 dired-…  1277     warning         All variables and subroutines might as well have a documentation string (emacs-lisp-checkdoc)
 dired-…  1299     warning         Argument ‘prompt’ should appear (as PROMPT) in the doc string (emacs-lisp-checkdoc)
 dired-…  1338     warning         Argument ‘name’ should appear (as NAME) in the doc string (emacs-lisp-checkdoc)
 dired-…  1365     warning         Argument ‘name’ should appear (as NAME) in the doc string (emacs-lisp-checkdoc)
```

### after
```
 dired-f…   405     warning         All variables and subroutines might as well have a documentation string (emacs-lisp-checkdoc)
 dired-…   408     warning         All variables and subroutines might as well have a documentation string (emacs-lisp-checkdoc)
 dired-…  1248     warning         Argument ‘arg’ should appear (as ARG) in the doc string (emacs-lisp-checkdoc)
 dired-…  1277     warning         All variables and subroutines might as well have a documentation string (emacs-lisp-checkdoc)
 dired-…  1299     warning         Argument ‘prompt’ should appear (as PROMPT) in the doc string (emacs-lisp-checkdoc)
 dired-…  1338     warning         Argument ‘name’ should appear (as NAME) in the doc string (emacs-lisp-checkdoc)
 dired-…  1365     warning         Argument ‘name’ should appear (as NAME) in the doc string (emacs-lisp-checkdoc)
```

## dired-hacks-utils
### before
```
 dired-ha…     1   1 error           Package should have a Homepage or URL header. (emacs-lisp-package)
 dired-ha…    50   1 error           "dired-hacks-file-size-formatter" doesn't start with package's prefix "dired-hacks-utils". (emacs-lisp-package)
 dired-ha…    57   1 error           "dired-hacks-datetime-regexp" doesn't start with package's prefix "dired-hacks-utils". (emacs-lisp-package)
 dired-ha…    71   1 error           Aliases should start with the package's prefix "dired-hacks-utils". (emacs-lisp-package)
 dired-ha…    86   1 error           "dired-utils-get-filename" doesn't start with package's prefix "dired-hacks-utils". (emacs-lisp-package)
 dired-h…    93   1 error           "dired-utils-get-all-files" doesn't start with package's prefix "dired-hacks-utils". (emacs-lisp-package)
 dired-h…   105   1 error           "dired-utils-file-attributes-keywords" doesn't start with package's prefix "dired-hacks-utils". (emacs-lisp-package)
 dired-h…   109   1 error           "dired-utils-info-keywords" doesn't start with package's prefix "dired-hacks-utils". (emacs-lisp-package)
 dired-h…   113   1 error           "dired-utils--get-keyword-info" doesn't start with package's prefix "dired-hacks-utils". (emacs-lisp-package)
 dired-h…   116   6 error           You should depend on (emacs "24.3") or the cl-lib package if you need `cl-case'. (emacs-lisp-package)
 dired-h…   125   1 error           "dired-utils-get-info" doesn't start with package's prefix "dired-hacks-utils". (emacs-lisp-package)
 dired-h…   140   1 error           "dired-utils-goto-line" doesn't start with package's prefix "dired-hacks-utils". (emacs-lisp-package)
 dired-h…   154   1 error           "dired-utils-match-filename-regexp" doesn't start with package's prefix "dired-hacks-utils". (emacs-lisp-package)
 dired-h…   166   1 error           "dired-utils-match-filename-extension" doesn't start with package's prefix "dired-hacks-utils". (emacs-lisp-package)
 dired-h…   177   1 error           "dired-utils-format-information-line" doesn't start with package's prefix "dired-hacks-utils". (emacs-lisp-package)
 dired-h…   195   1 error           "dired-utils-is-file-p" doesn't start with package's prefix "dired-hacks-utils". (emacs-lisp-package)
 dired-h…   199   1 error           "dired-utils-is-dir-p" doesn't start with package's prefix "dired-hacks-utils". (emacs-lisp-package)
 dired-h…   207   1 error           "dired-hacks-next-file" doesn't start with package's prefix "dired-hacks-utils". (emacs-lisp-package)
 dired-h…   227   1 error           "dired-hacks-previous-file" doesn't start with package's prefix "dired-hacks-utils". (emacs-lisp-package)
 dired-h…   246   1 error           "dired-hacks-compare-files" doesn't start with package's prefix "dired-hacks-utils". (emacs-lisp-package)
 dired-h…   263   1 error           "dired-utils-format-information-line-mode" doesn't start with package's prefix "dired-hacks-utils". (emacs-lisp-package)
```

### after
```
 dired-ha…    43   1 error           Cannot open load file: No such file or directory, dash (emacs-lisp)
 dired-ha…    51   1 error           "dired-hacks-file-size-formatter" doesn't start with package's prefix "dired-hacks-utils". (emacs-lisp-package)
 dired-ha…    58   1 error           "dired-hacks-datetime-regexp" doesn't start with package's prefix "dired-hacks-utils". (emacs-lisp-package)
 dired-ha…    72   1 error           Aliases should start with the package's prefix "dired-hacks-utils". (emacs-lisp-package)
 dired-ha…    87   1 error           "dired-utils-get-filename" doesn't start with package's prefix "dired-hacks-utils". (emacs-lisp-package)
 dired-h…    94   1 error           "dired-utils-get-all-files" doesn't start with package's prefix "dired-hacks-utils". (emacs-lisp-package)
 dired-h…   106   1 error           "dired-utils-file-attributes-keywords" doesn't start with package's prefix "dired-hacks-utils". (emacs-lisp-package)
 dired-h…   110   1 error           "dired-utils-info-keywords" doesn't start with package's prefix "dired-hacks-utils". (emacs-lisp-package)
 dired-h…   114   1 error           "dired-utils--get-keyword-info" doesn't start with package's prefix "dired-hacks-utils". (emacs-lisp-package)
 dired-h…   126   1 error           "dired-utils-get-info" doesn't start with package's prefix "dired-hacks-utils". (emacs-lisp-package)
 dired-h…   141   1 error           "dired-utils-goto-line" doesn't start with package's prefix "dired-hacks-utils". (emacs-lisp-package)
 dired-h…   155   1 error           "dired-utils-match-filename-regexp" doesn't start with package's prefix "dired-hacks-utils". (emacs-lisp-package)
 dired-h…   167   1 error           "dired-utils-match-filename-extension" doesn't start with package's prefix "dired-hacks-utils". (emacs-lisp-package)
 dired-h…   178   1 error           "dired-utils-format-information-line" doesn't start with package's prefix "dired-hacks-utils". (emacs-lisp-package)
 dired-h…   196   1 error           "dired-utils-is-file-p" doesn't start with package's prefix "dired-hacks-utils". (emacs-lisp-package)
 dired-h…   200   1 error           "dired-utils-is-dir-p" doesn't start with package's prefix "dired-hacks-utils". (emacs-lisp-package)
 dired-h…   208   1 error           "dired-hacks-next-file" doesn't start with package's prefix "dired-hacks-utils". (emacs-lisp-package)
 dired-h…   228   1 error           "dired-hacks-previous-file" doesn't start with package's prefix "dired-hacks-utils". (emacs-lisp-package)
 dired-h…   247   1 error           "dired-hacks-compare-files" doesn't start with package's prefix "dired-hacks-utils". (emacs-lisp-package)
 dired-h…   264   1 error           "dired-utils-format-information-line-mode" doesn't start with package's prefix "dired-hacks-utils". (emacs-lisp-package)
```