### PR TITLE
Fix for when free space is already human readable

### DIFF
--- a/dired-hacks-utils.el
+++ b/dired-hacks-utils.el
@@ -181,7 +181,7 @@ Each car in ALIST is a string representing file extension
     (forward-line)
     (let ((inhibit-read-only t)
           (limit (line-end-position)))
-      (while (re-search-forward "\\(?:directory\\|available\\) \\(\\<[0-9]+\\>\\)" nil t)
+      (while (re-search-forward "\\(?:directory\\|available\\) \\(\\<[0-9]+$\\>\\)" nil t)
         (replace-match
          (save-match-data
            (propertize (dired-utils--string-trim


### PR DESCRIPTION
Fix so that when the information line is already using human readable sizes, you get this:

```
  total used in directory 12M available 69.5 GiB
```

Instead of this:

```
  total used in directory 12M available 70.7k.5 GiB
```