### PR TITLE
Rewrite `dired-subtree--readin` to fix several bugs

### DIFF
--- a/dired-subtree.el
+++ b/dired-subtree.el
@@ -462,23 +462,20 @@ children."
   "Read in the directory.
 
 Return a string suitable for insertion in `dired' buffer."
-  (with-temp-buffer
-    (insert-directory dir-name dired-listing-switches nil t)
-    (delete-char -1)
-    (goto-char (point-min))
-    (delete-region
-     (progn (beginning-of-line) (point))
-     (progn (forward-line
-             (if (save-excursion
-                   (forward-line 1)
-                   (end-of-line)
-                   (looking-back "\\."))
-                 3 1)) (point)))
-    (insert "  ")
-    (while (= (forward-line) 0)
-      (insert "  "))
-    (delete-char -2)
-    (buffer-string)))
+  (let ((switches (or dired-actual-switches dired-listing-switches)))
+    (with-temp-buffer
+      (insert-directory dir-name switches nil t)
+      (delete-char -1)
+      (goto-char (point-min))
+      (delete-region (point) (progn (forward-line 1) (point)))
+      (save-match-data
+        (while (re-search-forward "^ *d.* \\.\\.?/?\n" nil t)
+          (delete-region (match-beginning 0) (match-end 0))))
+      (goto-char (point-min))
+      (unless (looking-at-p "  ")
+        (let ((indent-tabs-mode nil))
+          (indent-rigidly (point-min) (point-max) 2)))
+      (buffer-string))))
 
 ;;;###autoload
 (defun dired-subtree-insert ()


### PR DESCRIPTION
I found multiple issues with `dired-subtree--readin`, this fixes them:

* Breaks when `--dired` is included in `dired-listing-switches`.  You'll
  see that the nested directory is indented by 4 spaces instead of 2,
  which also makes inserting a nested subdirectory fail (since it checks
  that the line starts with exactly two spaces followed by a `d`).

  The problem is that the listing will already have the double-space
  prefix.  See `dired-insert-directory` which just uses `looking-at` to
  determine if it needs to add spaces or not.  I used the same code to
  add the indentation with `indent-rigidly`.

* When `-F` is used in the switches, the `.`/`..` entries are not
  removed, leading to failures.

  This is because they get a suffix of `/`.  Use a `/?$`-terminated
  regexp to find these lines.

* Also, if there are file names that precede `.`/`..`, the previous code
  would fail since it assumes that they must be first.

  Use a regexp loop that looks for these in the whole buffer rather than
  the first two lines.

* Also includes a slightly better version of #143, to avoid the conflict
  that would result from this PR.