### PR TITLE
dired-narrow: call `dired-narrow-find-file' when entering directory

### DIFF
--- a/dired-narrow.el
+++ b/dired-narrow.el
@@ -258,7 +258,11 @@ read from minibuffer."
         (funcall dired-narrow-exit-action))
       (cond
        ((equal disable-narrow "dired-narrow-enter-directory")
-        (dired-narrow--internal filter-function))))))
+        (if (file-directory-p dired-narrow--current-file)
+            (progn
+              (dired-narrow-find-file)
+              (dired-narrow--internal filter-function))
+          (dired-narrow-find-file)))))))
 
 
 ;; Interactive


### PR DESCRIPTION
## Information
|||
|--|--|
|Emacs Version|GNU Emacs 28.0.50.148618|
|OS|Arch Linux (5.12.15-arch1-1)|
|`emacs -q` ? | yes|

Emacs Configuration:
```elisp
(require 'package)
(package-initialize)

(unless (package-installed-p 'use-package)
  (package-refresh-contents)
  (package-install 'use-package))

(use-package dired-narrow
  :after (dired)
  :bind (:map dired-mode-map
        ("/" . dired-narrow)))
```

## Bug Description
May be related to #147 .
Please confirm that the described behavior is intended as such (I might not understand `dired-narrow-enter-directory` correctly).

### Expected Behavior
After entering `dired-narrow-mode` and selecting a directory (by filtering and moving the point), calling `dired-narrow-enter-directory` should enter the directory at point and start another dired-narrow minibuffer.

### Actual Behavior
After entering `dired-narrow-mode` and selecting a directory, calling `dired-narrow-enter-directory` does **not** enter the directory, but simply restarts narrowing in the current (already narrowed) directory.

## Change Description

Before this change, when `dired-narrow-enter-directory` was called, the `dired-narrow--internal` function did call itself to start another instance of dired narrow in the subdirectory. However it did *not* visit the directory at point, which restarted dired-narrow in the current (already filtered) directory.

With this change `dired-narrow-find-file` is called before restarting `dired-narrow--internal`. This will visit the directory at point and start another dired-narrow instance. If the current file is not a directory, visit the file at point.

## Comment
Thank you for maintaining this package!