### PR TITLE
assert dired-filter-mode after inserting a subtree

### DIFF
--- a/dired-subtree.el
+++ b/dired-subtree.el
@@ -540,6 +540,7 @@ Return a string suitable for insertion in `dired' buffer."
       (goto-char beg)
       (dired-move-to-filename)
       (read-only-mode 1)
+      (when (bound-and-true-p dired-filter-mode) (dired-filter-mode 1))
       (run-hooks 'dired-subtree-after-insert-hook))))
 
 ;;;###autoload


### PR DESCRIPTION
If dired-filter-mode is used and a subtree is inserted, this makes the inserted subtree respect the active filter(s)
fixes #191