### PR TITLE
Fixes on defcustom types

### DIFF
--- a/dired-avfs.el
+++ b/dired-avfs.el
@@ -69,14 +69,14 @@
 
 For example, this allows the user to open files via avfs from
 dired, but not from `find-file'."
-  :type '(repeat symbol)
+  :type '(repeat function)
   :group 'dired-avfs)
 
 (defcustom dired-avfs-file-size-threshold 100
   "Ask before opening files if their size exceeds this setting.
 
 The value is in megabytes."
-  :type 'integer
+  :type 'number
   :group 'dired-avfs)
 
 (defun dired-avfs--archive-filename (filename)

--- a/dired-hacks-utils.el
+++ b/dired-hacks-utils.el
@@ -47,11 +47,11 @@
   :group 'dired
   :prefix "dired-hacks-")
 
-(defcustom dired-hacks-file-size-formatter 'file-size-human-readable
+(defcustom dired-hacks-file-size-formatter #'file-size-human-readable
   "The function used to format file sizes.
 
 See `dired-utils-format-file-sizes'."
-  :type 'symbol
+  :type 'function
   :group 'dired-hacks)
 
 (defcustom dired-hacks-datetime-regexp
@@ -65,7 +65,7 @@ followed by at least one space character.  You should only use
 shy groups (prefixed with ?:) because the first group is used by
 the font-lock to determine what portion of the name should be
 colored."
-  :type 'string
+  :type 'regexp
   :group 'dired-hacks)
 
 (defalias 'dired-utils--string-trim

--- a/dired-images.el
+++ b/dired-images.el
@@ -19,22 +19,22 @@
 
 (defcustom di-thumb-relief 2
   ""
-  :type 'integer
+  :type 'natnum
   )
 
 (defcustom di-thumb-margin 3
   ""
-  :type 'integer
+  :type 'natnum
   )
 
 (defcustom di-thumb-width 200
   ""
-  :type 'integer
+  :type 'natnum
   )
 
 (defcustom di-thumb-height 115
   ""
-  :type 'integer
+  :type 'natnum
   )
 
 (defcustom di-thumb-track t

--- a/dired-list.el
+++ b/dired-list.el
@@ -67,6 +67,7 @@
 (require 'grep)
 (require 'find-dired)
 
+; TODO: this will become obsolete in 30.1, because -N always comes with --dired flag
 (defcustom dired-list-use-N-flag t
   "Non-nil means the --literal flag will be used.
 

--- a/dired-narrow.el
+++ b/dired-narrow.el
@@ -106,15 +106,14 @@ exit minibuffer and call `dired-narrow-exit-action'."
   :group 'dired-narrow)
 
 (defcustom dired-narrow-enable-blinking t
-  "If set to true highlight the chosen file shortly.
-This feature works only when `dired-narrow-exit-when-one-left' is true."
+  "If non-nil, highlight the chosen file shortly.
+Only works when `dired-narrow-exit-when-one-left' is non-nil."
   :type 'boolean
   :group 'dired-narrow)
 
 (defcustom dired-narrow-blink-time 0.2
-  "How long should be highlighted a chosen file.
-Units are seconds."
-  :type 'float
+  "How many seconds should a chosen file be highlighted."
+  :type 'number
   :group 'dired-narrow)
 
 (defface dired-narrow-blink

--- a/dired-open.el
+++ b/dired-open.el
@@ -80,17 +80,16 @@
 (defcustom dired-open-functions '(dired-open-by-extension dired-open-subdir)
   "List of functions to try to open a file.
 
-Each function should accept no argument and should retrieve the
+Each function should accept no arguments and should retrieve the
 filename and/or other context by itself.  Each function should
 return non-nil value if it succeeded in opening the file."
   :type 'hook
   :group 'dired-open)
 
-(defcustom dired-open-find-file-function 'dired-find-file
+(defcustom dired-open-find-file-function #'dired-find-file
   "A function that will be used if none of the `dired-open-functions' succeeded."
   :type 'function
   :group 'dired-open)
-
 
 (defcustom dired-open-extensions nil
   "Alist of extensions mapping to a programs to run them in.
@@ -111,8 +110,8 @@ The filename is passed as the only argument to the function."
   :group 'dired-open)
 
 (defcustom dired-open-use-nohup t
-  "If non-nil, use nohup(1) to keep external processes opened
-even if emacs process is terminated.
+  "If non-nil, use nohup to keep external processes alive.
+See man page `nohup(1)'.
 
 This only affects the built-in handlers."
   :type 'boolean
@@ -120,7 +119,7 @@ This only affects the built-in handlers."
 
 (defcustom dired-open-query-before-exit t
   "If non-nil, ask the user if they want to kill any external
-processes started by `dired-open-file' when they exit emacs.
+processes started by `dired-open-file' when they exit Emacs.
 
 This only affects the built-in handlers."
   :type 'boolean

--- a/dired-ranger.el
+++ b/dired-ranger.el
@@ -99,7 +99,7 @@
 ;; multi-stage copy/paste operations
 (defcustom dired-ranger-copy-ring-size 10
   "Specifies how many filesets for copy/paste operations should be stored."
-  :type 'integer
+  :type 'natnum
   :group 'dired-ranger)
 
 (defvar dired-ranger-copy-ring (make-ring dired-ranger-copy-ring-size))

--- a/dired-subtree.el
+++ b/dired-subtree.el
@@ -127,13 +127,13 @@ depth---that creates the prefix."
 
 (defcustom dired-subtree-cycle-depth 3
   "Default depth expanded by `dired-subtree-cycle'."
-  :type 'integer
+  :type 'natnum
   :group 'dired-subtree)
 
 (defcustom dired-subtree-ignored-regexp
   (concat "^" (regexp-opt vc-directory-exclusion-list) "$")
   "Matching directories will not be expanded in `dired-subtree-cycle'."
-  :type 'string
+  :type 'regexp
   :group 'dired-subtree)
 
 (defgroup dired-subtree-faces ()


### PR DESCRIPTION
Lots of updates on `defcustom` types.

Note that in dired-list.el, `dired-list-use-N-flag` will be obsolete as of Emacs 30.1.
