### PR TITLE
fix(collapse): Ensure dir actually readable before getting entries

### DIFF
--- a/dired-collapse.el
+++ b/dired-collapse.el
@@ -143,6 +143,7 @@ filename (for example when the final directory is empty)."
                     files)
                 (while (and (file-directory-p path)
                             (file-accessible-directory-p path)
+                            (f-readable? path)
                             (setq files (f-entries path))
                             (= 1 (length files)))
                   (setq path (car files)))


### PR DESCRIPTION
On macOS the ~/.Trash directory is "accessible" according to `file-accessible-directory-p` but it is *not* "readable", causing `f-entries` to fail. This makes opening `~/` in dired fail on macOS when dired-collapse-mode is on.

Also reported at https://github.com/Fuco1/dired-hacks/pull/182#issuecomment-1481062747