### PR TITLE
Fixes and adjustments to dired-collapse dependencies

### DIFF
--- a/dired-collapse.el
+++ b/dired-collapse.el
@@ -6,7 +6,7 @@
 ;; Maintainer: Matúš Goljer <matus.goljer@gmail.com>
 ;; Version: 1.1.0
 ;; Created: 15th July 2017
-;; Package-Requires: ((f "0.19.0") (s "1.13.1") (dired-hacks-utils "0.0.1"))
+;; Package-Requires: ((s "1.13.1") (dired-hacks-utils "0.0.1"))
 ;; Keywords: files
 
 ;; This program is free software; you can redistribute it and/or
@@ -64,7 +64,6 @@
 ;;; Code:
 
 (require 'dired)
-(require 'f)
 (require 'dired-hacks-utils)
 (require 's)                 ; for s-chop-prefix
 
@@ -144,7 +143,9 @@ filename (for example when the final directory is empty)."
                     files)
                 (while (and (file-directory-p path)
                             (file-accessible-directory-p path)
-                            (setq files (f-entries path))
+                            (setq files (directory-files path
+                                                         'full
+                                                         directory-files-no-dot-files-regexp))
                             (= 1 (length files)))
                   (setq path (car files)))
                 (if (and (not files)

--- a/dired-collapse.el
+++ b/dired-collapse.el
@@ -6,7 +6,7 @@
 ;; Maintainer: Matúš Goljer <matus.goljer@gmail.com>
 ;; Version: 1.1.0
 ;; Created: 15th July 2017
-;; Package-Requires: ((s "1.13.1") (dired-hacks-utils "0.0.1"))
+;; Package-Requires: ((s "1.13.1"))
 ;; Keywords: files
 
 ;; This program is free software; you can redistribute it and/or
@@ -64,7 +64,6 @@
 ;;; Code:
 
 (require 'dired)
-(require 'dired-hacks-utils)
 (require 's)                 ; for s-chop-prefix
 
 (defgroup dired-collapse ()
@@ -101,7 +100,7 @@
   (insert-directory file dired-listing-switches nil nil)
   (forward-line -1)
   (dired-align-file (line-beginning-position) (1+ (line-end-position)))
-  (when-let (replaced-file (dired-utils-get-filename))
+  (when-let (replaced-file (dired-get-filename nil t))
     (when (file-remote-p replaced-file)
       (while (search-forward (dired-current-directory) (line-end-position) t)
         (replace-match "")))))
@@ -135,11 +134,11 @@ filename (for example when the final directory is empty)."
       (save-excursion
         (goto-char (point-min))
         (while (not (eobp))
-          (when-let ((filename-no-dir (dired-utils-get-filename 'no-dir)))
+          (when-let ((filename-no-dir (dired-get-filename 'no-dir t)))
             (when (and (looking-at-p dired-re-dir)
                        (not (member filename-no-dir (list "." "..")))
                        (not (eolp)))
-              (let ((path (dired-utils-get-filename))
+              (let ((path (dired-get-filename nil t))
                     files)
                 (while (and (file-directory-p path)
                             (file-accessible-directory-p path)
@@ -149,7 +148,7 @@ filename (for example when the final directory is empty)."
                             (= 1 (length files)))
                   (setq path (car files)))
                 (if (and (not files)
-                         (equal path (dired-utils-get-filename)))
+                         (equal path (dired-get-filename nil t)))
                     (dired-collapse--create-ov 'to-eol)
                   (setq path (s-chop-prefix (dired-current-directory) path))
                   (when (string-match-p "/" path)

--- a/dired-collapse.el
+++ b/dired-collapse.el
@@ -6,7 +6,7 @@
 ;; Maintainer: Matúš Goljer <matus.goljer@gmail.com>
 ;; Version: 1.1.0
 ;; Created: 15th July 2017
-;; Package-Requires: ((dash "2.10.0") (f "0.19.0") (dired-hacks-utils "0.0.1"))
+;; Package-Requires: ((dash "2.10.0") (f "0.19.0") (s "1.13.1") (dired-hacks-utils "0.0.1"))
 ;; Keywords: files
 
 ;; This program is free software; you can redistribute it and/or
@@ -67,6 +67,7 @@
 (require 'dired)
 (require 'f)
 (require 'dired-hacks-utils)
+(require 's)                 ; for s-chop-prefix
 
 (defgroup dired-collapse ()
   "Collapse unique nested paths in dired listing."

--- a/dired-collapse.el
+++ b/dired-collapse.el
@@ -6,7 +6,7 @@
 ;; Maintainer: Matúš Goljer <matus.goljer@gmail.com>
 ;; Version: 1.1.0
 ;; Created: 15th July 2017
-;; Package-Requires: ((dash "2.10.0") (f "0.19.0") (s "1.13.1") (dired-hacks-utils "0.0.1"))
+;; Package-Requires: ((f "0.19.0") (s "1.13.1") (dired-hacks-utils "0.0.1"))
 ;; Keywords: files
 
 ;; This program is free software; you can redistribute it and/or
@@ -63,7 +63,6 @@
 
 ;;; Code:
 
-(require 'dash)
 (require 'dired)
 (require 'f)
 (require 'dired-hacks-utils)
@@ -103,7 +102,7 @@
   (insert-directory file dired-listing-switches nil nil)
   (forward-line -1)
   (dired-align-file (line-beginning-position) (1+ (line-end-position)))
-  (-when-let (replaced-file (dired-utils-get-filename))
+  (when-let (replaced-file (dired-utils-get-filename))
     (when (file-remote-p replaced-file)
       (while (search-forward (dired-current-directory) (line-end-position) t)
         (replace-match "")))))
@@ -128,11 +127,12 @@ filename (for example when the final directory is empty)."
 (defun dired-collapse ()
   "Collapse unique nested paths in dired listing."
   (when (or (not (file-remote-p default-directory)) dired-collapse-remote)
-    (-let* (;; dired-hide-details-mode hides details by assigning a special invisibility text property
-            ;; to them, while dired-collapse requires all the details. So we disable invisibility here
-            ;; temporarily.
-            (buffer-invisibility-spec nil)
-            (inhibit-read-only t))
+    (let (;; dired-hide-details-mode hides details by assigning a
+          ;; special invisibility text property to them, while
+          ;; dired-collapse requires all the details. So we disable
+          ;; invisibility here temporarily.
+          (buffer-invisibility-spec nil)
+          (inhibit-read-only t))
       (save-excursion
         (goto-char (point-min))
         (while (not (eobp))


### PR DESCRIPTION
The 'fix' in this PR is to require the s- package, which is used but
not declared.

The 'adjustments' in this PR are to remove several needless
dependencies.