### PR TITLE
feat(dired-collapse): apply overlay optionally

### DIFF
--- a/dired-collapse.el
+++ b/dired-collapse.el
@@ -78,6 +78,11 @@
   :type 'boolean
   :group 'dired-collapse)
 
+(defcustom dired-collapse-fontify t
+  "If non-nil, fontify with a shaded overlay."
+  :type 'boolean
+  :group 'dired-collapse)
+
 ;;;###autoload
 (define-minor-mode dired-collapse-mode
   "Toggle collapsing of unique nested paths in Dired."
@@ -148,13 +153,15 @@ filename (for example when the final directory is empty)."
                   (setq path (car files)))
                 (if (and (not files)
                          (equal path (dired-utils-get-filename)))
-                    (dired-collapse--create-ov 'to-eol)
+                    (when dired-collapse-fontify
+                      (dired-collapse--create-ov 'to-eol))
                   (setq path (s-chop-prefix (dired-current-directory) path))
                   (when (string-match-p "/" path)
                     (let ((default-directory (dired-current-directory)))
                       (dired-collapse--replace-file path))
                     (dired-insert-set-properties (line-beginning-position) (line-end-position))
-                    (dired-collapse--create-ov (= 0 (length files))))))))
+                    (when dired-collapse-fontify
+                      (dired-collapse--create-ov (= 0 (length files)))))))))
           (forward-line 1))))))
 
 (provide 'dired-collapse)


### PR DESCRIPTION
Create a boolean customization variable dired-collapse-fontify to
control whether to apply the fontification overlay to collapsed dired
lines.

This allows users to apply other fontification options to collapsed
dired lines.