### PR TITLE
dired-open-xdg: file path could contain quotes. use `call-process`.

### DIFF
--- a/dired-open.el
+++ b/dired-open.el
@@ -163,7 +163,8 @@ string as well."
   (interactive)
   (if (executable-find "xdg-open")
       (let ((file (ignore-errors (dired-get-file-for-visit))))
-        (call-process-shell-command (concat "xdg-open '" (file-truename file) "'"))
+        (call-process "xdg-open" nil nil nil
+					  (file-truename file))
     nil)))
 
 (defun dired-open-by-extension ()


### PR DESCRIPTION
In `dired-open-xdg`, the shell command is constructed using `concat` to be run by `call-process-shell-command`, and file path as an argument is surrounded by single quotes `'` to prevent escaping most special characters except single quote itself.
Thus, if the `file` contains single quotes anywhere in the path it will not be opened by `dired-open-xdg` as the shell would not consider it as a whole word.
Using `call-process` would pass ARGS straight to the program as one, eliminating the issue of quotes as well as other shell special characters.