### PR TITLE
add a check to dired-subtree--readin, if a listing is already indented

### DIFF
--- a/dired-subtree.el
+++ b/dired-subtree.el
@@ -475,10 +475,13 @@ Return a string suitable for insertion in `dired' buffer."
                    (end-of-line)
                    (looking-back "\\."))
                  3 1)) (point)))
-    (insert "  ")
-    (while (= (forward-line) 0)
-      (insert "  "))
-    (delete-char -2)
+    ;; we want to indent the listing by " ", but have to take care that the
+    ;; "--dired" option to ls hasn't done that already
+    (when (not (string-equal "  " (buffer-substring-no-properties (point) (+ (point) 2))))
+      (insert "  ")
+      (while (= (forward-line) 0)
+        (insert "  "))
+      (delete-char -2))
     (buffer-string)))
 
 ;;;###autoload

--- a/dired-subtree.el
+++ b/dired-subtree.el
@@ -459,7 +459,7 @@ children."
       (when file-name
         (dired-utils-goto-line file-name)))))
 
-(defun dired-subtree--readin (dir-name)
+  (defun dired-subtree--readin (dir-name)
   "Read in the directory.
 
 Return a string suitable for insertion in `dired' buffer."
@@ -477,12 +477,14 @@ Return a string suitable for insertion in `dired' buffer."
                  3 1)) (point)))
     ;; we want to indent the listing by " ", but have to take care that the
     ;; "--dired" option to ls hasn't done that already
-    (when (not (string-equal "  " (buffer-substring-no-properties (point) (+ (point) 2))))
-      (insert "  ")
-      (while (= (forward-line) 0)
-        (insert "  "))
-      (delete-char -2))
-    (buffer-string)))
+    (let* ((beg (point))
+           (end (min (+ beg 2) (point-max))))
+      (when (not (string-equal "  " (buffer-substring-no-properties beg end)))
+        (insert "  ")
+        (while (= (forward-line) 0)
+          (insert "  "))
+        (delete-char -2))
+    (buffer-string))))
 
 ;;;###autoload
 (defun dired-subtree-insert ()

--- a/dired-subtree.el
+++ b/dired-subtree.el
@@ -459,7 +459,7 @@ children."
       (when file-name
         (dired-utils-goto-line file-name)))))
 
-  (defun dired-subtree--readin (dir-name)
+(defun dired-subtree--readin (dir-name)
   "Read in the directory.
 
 Return a string suitable for insertion in `dired' buffer."


### PR DESCRIPTION
Hi,

this is a patch for my problem in https://github.com/Fuco1/dired-hacks/issues/229
Turns out that it isn't a tramp problem. It's a `ls --dired` problem.

Example listing:
```
me@mine:~# ls -l
insgesamt 4
drwxr-xr-x 2 root root 4096 13. Apr 18:15 test
-rw-r--r-- 1 root root    0 13. Apr 18:15 test.txt
```
vs
```
me@mine:~# ls -l --dired
  insgesamt 4
  drwxr-xr-x 2 root root 4096 13. Apr 18:15 test
  -rw-r--r-- 1 root root    0 13. Apr 18:15 test.txt
//DIRED// 58 62 107 115
//DIRED-OPTIONS// --quoting-style=shell-escape
```

If `--dired` is one of the listing switches, the listing will be indented by two whitespaces, `insert-directory` will clean up the DIRED lines but not the indentation, and then `dired-subtree--readin` prepends two additional whitespaces. Due to these additional whitespaces, the directories in the subdirectory will not be identified as such and further levels of subdirectories will not work. This is patched here: if two whitespaces are detected in the beginning of the listing, no further whitespaces will be added. 

NB: Since tramp for example will use `--dired` if it is available, a check if `--dired` is in `dired-listing-switches` wouldn't suffice, so we simply check for two whitespaces at the beginning of the listing to decide if we still have to prepend.